### PR TITLE
Add InstanceNorm

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Flatten
 Gemm
 GlobalAveragePool
 GlobalMaxPool
+InstanceNormalization
 LSTM
 LeakyRelu
 MatMul

--- a/src/ONNXNaiveNASflux.jl
+++ b/src/ONNXNaiveNASflux.jl
@@ -10,8 +10,8 @@ using NaiveNASflux
 using NaiveNASflux: weights, bias
 using NaiveNASflux: indim, outdim, actdim, actrank, layertype, wrapped
 using NaiveNASflux: FluxLayer, FluxParLayer, FluxNoParLayer, FluxDense, FluxConvolutional, FluxConv, FluxBatchNorm, 
-                    FluxRecurrent, FluxRnn, FluxLstm, FluxGru, FluxTransparentLayer, FluxPoolLayer, FluxDropOut, Flux2D,
-                    GenericFluxConvolutional, GenericFlux2D, GenericFluxRecurrent
+                    FluxInstanceNorm, FluxRecurrent, FluxRnn, FluxLstm, FluxGru, FluxTransparentLayer, FluxPoolLayer,
+                    FluxDropOut, Flux2D, GenericFluxConvolutional, GenericFlux2D, GenericFluxRecurrent
 using Setfield
 using Statistics
 import Pkg

--- a/test/deserialize/Artifacts.toml
+++ b/test/deserialize/Artifacts.toml
@@ -83,7 +83,7 @@ git-tree-sha1 = "8be97aa969ebdbe7599798d511a7790eba0697f2"
 git-tree-sha1 = "41eca620fb09f7d90ec9b875a80388566baadada"
 
 [test_div]
-git-tree-sha1 = "430fd9135e60076904f717971bd174b0f16e1c54"
+git-tree-sha1 = "57dd66f7274aac0e2a462e49dadf5a551c4e5e80"
 
 [test_dropout_default]
 git-tree-sha1 = "70fe420142b8d29b708578e4b6f2929e6907cb4c"
@@ -185,7 +185,7 @@ git-tree-sha1 = "c8b0d06dc9733222906bb6471c39a9c41270d149"
 git-tree-sha1 = "19fe9305067a4225c6dd76264bb342cf966546ae"
 
 [test_matmul_2d]
-git-tree-sha1 = "481de0ea5b1fb4692f10920215ce701df1b7ba09"
+git-tree-sha1 = "3008bfa77da6160c406f6dae414b19861fef9f13"
 
 [test_maxpool_1d_default]
 git-tree-sha1 = "9b0a2b97518eb68122276b242313529582e4be95"
@@ -278,10 +278,10 @@ git-tree-sha1 = "44c37442a35def50d4e1230cdcff8a986899d18d"
 git-tree-sha1 = "dc4a6180985e796aca6997ae79137fee6f9c05e9"
 
 [test_sigmoid]
-git-tree-sha1 = "2bb16571d0809d1e6216a1b6eb5b27d332fac4f0"
+git-tree-sha1 = "6f0e41cd8b1498f3c60b3d00b9558bf311217bf8"
 
 [test_sigmoid_example]
-git-tree-sha1 = "710a8b85b3a7e9e301af21f8f1c0e7b087536ba5"
+git-tree-sha1 = "b8b836fd3cb97d2801777c03e98d6cd41bc17b2d"
 
 [test_softmax_axis_0]
 git-tree-sha1 = "4f090b0b0f540b5f133176e4cf8a118c24db1886"

--- a/test/deserialize/Artifacts.toml
+++ b/test/deserialize/Artifacts.toml
@@ -169,6 +169,12 @@ git-tree-sha1 = "377710458916cc790bb7eec00c8e3f0719680cf8"
 [test_globalmaxpool_precomputed]
 git-tree-sha1 = "6d72b58370176351d46937ca3df65ba2fd114f04"
 
+[test_instancenorm_epsilon]
+git-tree-sha1 = "9b14c628a483dd94105ce207fca8e7ca6cb10e45"
+
+[test_instancenorm_example]
+git-tree-sha1 = "e63a946ae5c5b3becf847f4e3adaaf92ef9b358f"
+
 [test_leakyrelu]
 git-tree-sha1 = "07afe319b71db2cb6bc295ff9409482721473817"
 

--- a/test/deserialize/deserialize.jl
+++ b/test/deserialize/deserialize.jl
@@ -90,6 +90,8 @@ end
     (name="test_gemm_default_zero_bias", ninputs=3, noutputs=1),
     #(name="test_gemm_transposeA", ninputs=3, noutputs=1), Not supported!
     (name="test_gemm_transposeB", ninputs=3, noutputs=1),
+    (name="test_instancenorm_epsilon", ninputs=3, noutputs=1),
+    (name="test_instancenorm_example", ninputs=3, noutputs=1),
     (name="test_lstm_defaults", ninputs=3, noutputs=1),
     (name="test_lstm_with_initial_bias", ninputs=4, noutputs=1),
     # (name="test_lstm_with_peepholes", ninputs=8, noutputs=1), Not supported!

--- a/test/serialize/serialize.jl
+++ b/test/serialize/serialize.jl
@@ -277,7 +277,7 @@
         end
 
         @testset "$(tc.layer) node" for tc in (
-            (layer=BatchNorm(3, relu; initβ = i -> collect(Float32, 1:i), initγ = i -> collect(Float32, i:-1:1), ϵ=1e-3, momentum = 0.78), indata=reshape(collect(Float32, 1:2*3*3), 2,3,3,1) .- 10),
+            (layer=BatchNorm(3, relu; initβ = i -> collect(Float32, 1:i), initγ = i -> collect(Float32, i:-1:1), eps=1e-3, momentum = 0.78), indata=reshape(collect(Float32, 1:2*3*3), 2,3,3,1) .- 10),
             )
 
             inprobe = NodeProbe("input", genname)


### PR DESCRIPTION
I added `InstanceNorm` in a similar way to how `BatchNorm` was added.

It will only work for `Flux.InstanceNorm` layers with `affine=true` and `track_stats=false` unfortunately, since the ONNX InstanceNormalization layer requires that (for `BatchNorm` we also require `affine=true` though).