### PR TITLE
Replace broadcast override machinery for AbstractProbes when serializing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: true
       matrix:
         version:
-          - '1.9' # Trying to not waste my minutes here...
+          - '1.10' # Trying to not waste my minutes here...
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
It seems the hacky machinery to selectively override broadcasting of AbstractProbes when serializing was broken by some recent Julia version. This version is hopefully more stable.